### PR TITLE
release: remove LLVM, update Go to 1.13.5, and update TinyGo to 0.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stable-slim
 
 RUN apt-get clean && apt-get update && \
-    apt-get install -y wget gcc gcc-avr avr-libc gnupg
+    apt-get install -y wget gcc gcc-avr avr-libc
 
 ENV GO_RELEASE=1.13.5
 RUN wget https://dl.google.com/go/go${GO_RELEASE}.linux-amd64.tar.gz && \
@@ -16,7 +16,7 @@ RUN wget https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_RELEAS
     rm tinygo${TINYGO_RELEASE}.linux-amd64.tar.gz
 ENV PATH=${PATH}:/usr/local/tinygo/bin
 
-RUN apt-get remove -y wget gnupg && \
+RUN apt-get remove -y wget && \
     apt-get autoremove -y && \
     apt-get clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,18 +3,14 @@ FROM debian:stable-slim
 RUN apt-get clean && apt-get update && \
     apt-get install -y wget gcc gcc-avr avr-libc gnupg
 
-RUN echo 'deb http://apt.llvm.org/buster/ llvm-toolchain-buster-9 main' > /etc/apt/sources.list.d/clang-9.list
-RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN apt-get update && apt-get install -y --no-install-recommends clang-9
-
-ENV GO_RELEASE=1.13.4
+ENV GO_RELEASE=1.13.5
 RUN wget https://dl.google.com/go/go${GO_RELEASE}.linux-amd64.tar.gz && \
     tar xfv go${GO_RELEASE}.linux-amd64.tar.gz -C /usr/local && \
     rm go${GO_RELEASE}.linux-amd64.tar.gz && \
     find /usr/local/go -mindepth 1 -maxdepth 1 ! -name 'src' ! -name 'VERSION' -exec rm -rf {} +
 ENV PATH=${PATH}:/usr/local/go/bin
 
-ENV TINYGO_RELEASE=0.10.0
+ENV TINYGO_RELEASE=0.11.0
 RUN wget https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_RELEASE}/tinygo${TINYGO_RELEASE}.linux-amd64.tar.gz && \
     tar xfv tinygo${TINYGO_RELEASE}.linux-amd64.tar.gz -C /usr/local && \
     rm tinygo${TINYGO_RELEASE}.linux-amd64.tar.gz


### PR DESCRIPTION
This PR updates the release Docker image by removing LLVM (no longer needed in new TinyGo), installing the 1.13.5 version of Go, and then the new 0.11.0 version of TinyGo.