### PR TITLE
Fix Go version and include go binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ FROM debian:stable-slim
 RUN apt-get clean && apt-get update && \
     apt-get install -y wget gcc gcc-avr avr-libc
 
-ENV GO_RELEASE=1.5
+ENV GO_RELEASE=1.15
 RUN wget https://dl.google.com/go/go${GO_RELEASE}.linux-amd64.tar.gz && \
     tar xfv go${GO_RELEASE}.linux-amd64.tar.gz -C /usr/local && \
     rm go${GO_RELEASE}.linux-amd64.tar.gz && \
-    find /usr/local/go -mindepth 1 -maxdepth 1 ! -name 'src' ! -name 'VERSION' -exec rm -rf {} +
+    find /usr/local/go -mindepth 1 -maxdepth 1 ! -name 'src' ! -name 'VERSION' ! -name 'bin' ! -name 'pkg' -exec rm -rf {} +
 ENV PATH=${PATH}:/usr/local/go/bin
 
 ENV TINYGO_RELEASE=0.14.1


### PR DESCRIPTION
fix following issue

docker run causes this error: "error: cannot locate $GOROOT, please set it manually"
https://github.com/tinygo-org/tinygo/issues/1302