### PR TITLE
Adding git to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stable-slim
 
 RUN apt-get clean && apt-get update && \
-    apt-get install -y wget gcc gcc-avr avr-libc
+    apt-get install -y wget gcc gcc-avr avr-libc git
 
 ENV GO_RELEASE=1.18.3
 RUN wget https://dl.google.com/go/go${GO_RELEASE}.linux-amd64.tar.gz && \


### PR DESCRIPTION
git is used by go to retrieve libraries
/closes #15 