### PR TITLE
feat: add multi-arch docker build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,11 +47,20 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - 
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'arm64,arm'
+      - 
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,22 @@
-FROM debian:stable-slim
+FROM --platform=${BUILDPLATFORM} debian:stable-slim
+
+ARG TARGETOS
+ARG TARGETARCH
 
 RUN apt-get clean && apt-get update && \
-    apt-get install -y wget gcc gcc-avr avr-libc
+    apt-get install -y wget gcc gcc-avr avr-libc git
 
 ENV GO_RELEASE=1.18.3
-RUN wget https://dl.google.com/go/go${GO_RELEASE}.linux-amd64.tar.gz && \
-    tar xfv go${GO_RELEASE}.linux-amd64.tar.gz -C /usr/local && \
-    rm go${GO_RELEASE}.linux-amd64.tar.gz && \
+RUN wget https://dl.google.com/go/go${GO_RELEASE}.${TARGETOS}-${TARGETARCH}.tar.gz && \
+    tar xfv go${GO_RELEASE}.${TARGETOS}-${TARGETARCH}.tar.gz -C /usr/local && \
+    rm go${GO_RELEASE}.${TARGETOS}-${TARGETARCH}.tar.gz && \
     find /usr/local/go -mindepth 1 -maxdepth 1 ! -name 'src' ! -name 'VERSION' ! -name 'bin' ! -name 'pkg' -exec rm -rf {} +
 ENV PATH=${PATH}:/usr/local/go/bin
 
 ENV TINYGO_RELEASE=0.25.0
-RUN wget https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_RELEASE}/tinygo${TINYGO_RELEASE}.linux-amd64.tar.gz && \
-    tar xfv tinygo${TINYGO_RELEASE}.linux-amd64.tar.gz -C /usr/local && \
-    rm tinygo${TINYGO_RELEASE}.linux-amd64.tar.gz
+RUN wget https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_RELEASE}/tinygo${TINYGO_RELEASE}.${TARGETOS}-${TARGETARCH}.tar.gz && \
+    tar xfv tinygo${TINYGO_RELEASE}.${TARGETOS}-${TARGETARCH}.tar.gz -C /usr/local && \
+    rm tinygo${TINYGO_RELEASE}.${TARGETOS}-${TARGETARCH}.tar.gz
 ENV PATH=${PATH}:/usr/local/tinygo/bin
 
 RUN apt-get remove -y wget && \


### PR DESCRIPTION
Minimal changes to allow multi-arch docker builds. I've added git to the image.

To build images with new platforms, just add them in the `platforms` entry in the `Set up QEMU` and `Build and push` steps.