### PR TITLE
fix bug buildplatform, added unittest, added non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,50 @@
-FROM --platform=${BUILDPLATFORM} debian:stable-slim
+# Local image to download dependencies
+# No emulation, runs with host arch
+FROM --platform=${BUILDPLATFORM} debian:stable-slim as base
 
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN apt-get clean && apt-get update && \
-    apt-get install -y wget gcc gcc-avr avr-libc git
+RUN  apt-get clean && apt-get update && \
+    apt-get install -y wget
 
 ENV GO_RELEASE=1.18.3
 RUN wget https://dl.google.com/go/go${GO_RELEASE}.${TARGETOS}-${TARGETARCH}.tar.gz && \
     tar xfv go${GO_RELEASE}.${TARGETOS}-${TARGETARCH}.tar.gz -C /usr/local && \
-    rm go${GO_RELEASE}.${TARGETOS}-${TARGETARCH}.tar.gz && \
     find /usr/local/go -mindepth 1 -maxdepth 1 ! -name 'src' ! -name 'VERSION' ! -name 'bin' ! -name 'pkg' -exec rm -rf {} +
-ENV PATH=${PATH}:/usr/local/go/bin
+
 
 ENV TINYGO_RELEASE=0.25.0
 RUN wget https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_RELEASE}/tinygo${TINYGO_RELEASE}.${TARGETOS}-${TARGETARCH}.tar.gz && \
-    tar xfv tinygo${TINYGO_RELEASE}.${TARGETOS}-${TARGETARCH}.tar.gz -C /usr/local && \
-    rm tinygo${TINYGO_RELEASE}.${TARGETOS}-${TARGETARCH}.tar.gz
-ENV PATH=${PATH}:/usr/local/tinygo/bin
+    tar xfv tinygo${TINYGO_RELEASE}.${TARGETOS}-${TARGETARCH}.tar.gz -C /usr/local
 
-RUN apt-get remove -y wget && \
-    apt-get autoremove -y && \
-    apt-get clean
+
+# Build final image, emulation, runs as TARGETARCH
+FROM debian:stable-slim as build
+
+RUN apt-get clean && apt-get update && \
+    apt-get install -y gcc gcc-avr avr-libc git --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN useradd -ms /bin/bash tinygo
+USER tinygo
+WORKDIR /home/tinygo   
+
+COPY --from=base /usr/local/go /usr/local/go
+COPY --from=base /usr/local/tinygo /usr/local/tinygo
+
+ENV PATH=${PATH}:/usr/local/tinygo/bin
+ENV PATH=${PATH}:/usr/local/go/bin
+
+# Run a unittest to validate that the image arch and the compiled version matches
+FROM build as UnitTest
+
+ARG TARGETARCH
+RUN  export TINY_ARCH=$(tinygo info | grep GOARCH | awk '{print $2}') && \
+    if [ "${TARGETARCH}" != "${TINY_ARCH}" ]; then exit 1; else exit 0; fi
+
+
+# Final image, runs as TARGETARCH
+FROM build as final
 
 CMD ["tinygo"]


### PR DESCRIPTION
I realised that I made a mistake on my previous PR 😱, the arm64 image was using the amd64 binaries 🤦.

This  PR fixes that problem and adds a test to validate that the arch used to compile the binaries is the same as the docker image.

I've added a non-root user also, to make it more security friendly.

The unit test runs in a docker stage that we discard. 

The final image is slightly smaller as well 😄 