### PR TITLE
Add GNU Make to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN wget https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_RELEAS
 FROM debian:stable-slim as build
 
 RUN apt-get clean && apt-get update && \
-    apt-get install -y gcc git sudo && \
+    apt-get install -y gcc git sudo make && \
     rm -rf /var/lib/apt/lists/*
 
 RUN useradd -ms /bin/bash tinygo

--- a/README.md
+++ b/README.md
@@ -10,4 +10,5 @@ docker pull ghcr.io/tinygo-org/tinygo
 
 Older versions are on Docker Hub at https://hub.docker.com/r/tinygo/tinygo
 
-For information on how to use this, please see [https://tinygo.org/getting-started/using-docker/](https://tinygo.org/getting-started/using-docker/)
+For information on how to use this, please see
+https://tinygo.org/getting-started/install/using-docker/.


### PR DESCRIPTION
When using this docker image in GitHub Actions, it's nice to have access to `make`.
Also fix broken link in README.md.
